### PR TITLE
BITMAKER-1804: Rename Bitmaker Cloud CLI to Estela

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<h1 align="center"> Bitmaker Cloud CLI </h1>
+<h1 align="center"> Estela CLI </h1>
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-Bitmaker Cloud CLI is the command line client to interact with Bitmaker Cloud API. Allows the user to perform the following actions:
-- Link a Scrapy project with a project in Bitmaker Cloud.
-- Create projects, jobs, and cronjobs in Bitmaker Cloud.
+Estela CLI is the command line client to interact with Estela API. Allows the user to perform the following actions:
+- Link a Scrapy project with a project in Estela.
+- Create projects, jobs, and cronjobs in Estela.
 - Get the data of a job.
 
 ```bash
-$ bitmaker
-Usage: bitmaker [OPTIONS] COMMAND [ARGS]...
+$ estela
+Usage: estela [OPTIONS] COMMAND [ARGS]...
 
 Options:
   --version   Show the version and exit.
@@ -20,9 +20,9 @@ Commands:
   context  Show your current context
   create   Create a resource
   delete   Delete a resource
-  deploy   Deploy Scrapy project to Bitmaker Cloud
+  deploy   Deploy Scrapy project to Estela API
   data     Returns all the data of a job and saves it in a json file
-  init     Initialize bitmaker project for existing scrapy project
+  init     Initialize estela project for existing scrapy project
   list     Display the available resources
   login    Save your credentials
   logout   Remove your credentials

--- a/bm_cli/context.py
+++ b/bm_cli/context.py
@@ -9,7 +9,7 @@ from bm_cli.utils import (
     get_username_from_env,
     get_password_from_env,
 )
-from bm_cli.templates import BITMAKER_AUTH_NAME, OK_EMOJI, BAD_EMOJI
+from bm_cli.templates import ESTELA_AUTH_NAME, OK_EMOJI, BAD_EMOJI
 
 
 SHORT_HELP = "Show your current context"
@@ -42,14 +42,14 @@ def bm_command():
         if bm_auth is None:
             click.echo(
                 "Environment variables not declared, ~/{} not found.".format(
-                    BITMAKER_AUTH_NAME
+                    ESTELA_AUTH_NAME
                 )
             )
             return
 
         click.echo(
-            "You are currently using ~/{} file to configure bitmaker CLI.".format(
-                BITMAKER_AUTH_NAME
+            "You are currently using ~/{} file to configure estela CLI.".format(
+                ESTELA_AUTH_NAME
             )
         )
 
@@ -67,7 +67,7 @@ def bm_command():
             return
     else:
         click.echo(
-            "You are currently using environment variables to configure bitmaker CLI."
+            "You are currently using environment variables to configure estela CLI."
         )
         try:
             test_host(host)

--- a/bm_cli/create/project.py
+++ b/bm_cli/create/project.py
@@ -19,7 +19,7 @@ def bm_command(name):
         response = bm_client.create_project(name)
         click.echo("project/{} created.".format(name))
         click.echo(
-            "Hint: Run 'bitmaker init {}' to activate this project".format(
+            "Hint: Run 'estela init {}' to activate this project".format(
                 response["pid"]
             )
         )

--- a/bm_cli/deploy.py
+++ b/bm_cli/deploy.py
@@ -7,14 +7,14 @@ from bm_cli.utils import get_project_path, get_bm_settings, _in, get_bm_dockerfi
 from bm_cli.login import login
 from bm_cli.templates import (
     OK_EMOJI,
-    BITMAKER_DIR,
-    BITMAKER_YAML_NAME,
+    ESTELA_DIR,
+    ESTELA_YAML_NAME,
     DOCKERFILE,
     DOCKERFILE_NAME,
 )
 
 
-SHORT_HELP = "Deploy Scrapy project to Bitmaker Cloud"
+SHORT_HELP = "Deploy Scrapy project to Estela "
 
 
 def zip_project(pid, project_path):
@@ -52,13 +52,13 @@ def update_dockerfile(requirements_path, python_version):
     with open(dockerfile_path, "r") as dock:
         if result == dock.read():
             click.echo(
-                "{}/{} not changes to update.".format(BITMAKER_DIR, DOCKERFILE_NAME)
+                "{}/{} not changes to update.".format(ESTELA_DIR, DOCKERFILE_NAME)
             )
             return
 
     with open(dockerfile_path, "w+") as dockerfile:
         dockerfile.write(result)
-        click.echo("{}/{} updated successfully.".format(BITMAKER_DIR, DOCKERFILE_NAME))
+        click.echo("{}/{} updated successfully.".format(ESTELA_DIR, DOCKERFILE_NAME))
 
 
 @click.command(short_help=SHORT_HELP)
@@ -73,7 +73,7 @@ def bm_command():
         bm_client.get_project(pid)
     except:
         raise click.ClickException(
-            "Invalid project at {}/{}.".format(BITMAKER_DIR, BITMAKER_YAML_NAME)
+            "Invalid project at {}/{}.".format(ESTELA_DIR, ESTELA_YAML_NAME)
         )
 
     update_dockerfile(p_settings["requirements"], p_settings["python"])

--- a/bm_cli/init.py
+++ b/bm_cli/init.py
@@ -12,22 +12,22 @@ from bm_cli.templates import (
     DATA_DIR,
     DOCKERFILE,
     DOCKERFILE_NAME,
-    BITMAKER_YAML,
-    BITMAKER_YAML_NAME,
+    ESTELA_YAML,
+    ESTELA_YAML_NAME,
     DOCKER_DEFAULT_REQUIREMENTS,
     DOCKER_DEFAULT_PYTHON_VERSION,
-    BITMAKER_DIR,
+    ESTELA_DIR,
 )
 
 
-SHORT_HELP = "Initialize bitmaker project for existing scrapy project"
+SHORT_HELP = "Initialize estela project for existing scrapy project"
 
 
 def gen_bm_yaml(bm_client, pid=None):
     bm_yaml_path = get_bm_yaml_path()
 
     if os.path.exists(bm_yaml_path):
-        raise click.ClickException("{} file already exists.".format(BITMAKER_YAML_NAME))
+        raise click.ClickException("{} file already exists.".format(ESTELA_YAML_NAME))
 
     try:
         if pid is None:
@@ -39,7 +39,7 @@ def gen_bm_yaml(bm_client, pid=None):
             "The project with id '{}' does not exists.".format(pid)
         )
 
-    template = Template(BITMAKER_YAML)
+    template = Template(ESTELA_YAML)
     values = {
         "project_pid": pid,
         "project_data_path": DATA_DIR,
@@ -52,7 +52,7 @@ def gen_bm_yaml(bm_client, pid=None):
     with open(bm_yaml_path, "w") as bm_yaml:
         bm_yaml.write(result)
         click.echo(
-            "{}/{} file created successfully.".format(BITMAKER_DIR, BITMAKER_YAML_NAME)
+            "{}/{} file created successfully.".format(ESTELA_DIR, ESTELA_YAML_NAME)
         )
 
 
@@ -61,7 +61,7 @@ def gen_dockerfile(requirements_path):
 
     if os.path.exists(dockerfile_path):
         raise click.ClickException(
-            "{}/{} already exists.".format(BITMAKER_DIR, DOCKERFILE_NAME)
+            "{}/{} already exists.".format(ESTELA_DIR, DOCKERFILE_NAME)
         )
 
     project_path = get_project_path()
@@ -79,7 +79,7 @@ def gen_dockerfile(requirements_path):
 
     with open(dockerfile_path, "w") as dockerfile:
         dockerfile.write(result)
-        click.echo("{}/{} created successfully.".format(BITMAKER_DIR, DOCKERFILE_NAME))
+        click.echo("{}/{} created successfully.".format(ESTELA_DIR, DOCKERFILE_NAME))
 
 
 @click.command(short_help=SHORT_HELP)
@@ -92,13 +92,13 @@ def gen_dockerfile(requirements_path):
     show_default=True,
 )
 def bm_command(pid, requirements):
-    """Initialize bitmaker project
+    """Initialize estela project
 
     PID is the project's pid
     """
 
-    if not os.path.exists(BITMAKER_DIR):
-        os.makedirs(BITMAKER_DIR)
+    if not os.path.exists(ESTELA_DIR):
+        os.makedirs(ESTELA_DIR)
 
     bm_client = login()
     gen_bm_yaml(bm_client, pid)

--- a/bm_cli/login.py
+++ b/bm_cli/login.py
@@ -11,7 +11,7 @@ from bm_cli.utils import (
     get_bm_auth,
     get_home_path,
 )
-from bm_cli.templates import BITMAKER_AUTH_NAME, BITMAKER_AUTH
+from bm_cli.templates import ESTELA_AUTH_NAME, ESTELA_AUTH
 
 
 DEFAULT_BM_API_HOST = "http://localhost"
@@ -38,8 +38,8 @@ def yaml_login():
 
     if bm_auth is None:
         raise Exception(
-            "File ~/{} not found. It is recommended to login with 'bitmaker login'.".format(
-                BITMAKER_AUTH_NAME
+            "File ~/{} not found. It is recommended to login with 'estela login'.".format(
+                ESTELA_AUTH_NAME
             )
         )
 
@@ -48,7 +48,7 @@ def yaml_login():
     except:
         raise Exception(
             "Invalid context stored in ~/{}. Please login again.".format(
-                BITMAKER_AUTH_NAME
+                ESTELA_AUTH_NAME
             )
         )
 
@@ -75,7 +75,7 @@ def login(username=None, password=None, host=None):
     try:
         bm_client = env_login()
         click.echo(
-            "You are currently using environment variables to configure bitmaker CLI."
+            "You are currently using environment variables to configure estela CLI."
         )
         return bm_client
     except:
@@ -110,11 +110,11 @@ def login(username=None, password=None, host=None):
 )
 def bm_command(username, password, host):
     home_path = get_home_path()
-    bm_auth_path = os.path.join(home_path, BITMAKER_AUTH_NAME)
+    bm_auth_path = os.path.join(home_path, ESTELA_AUTH_NAME)
 
     if os.path.exists(bm_auth_path):
         raise click.ClickException(
-            "You already logged in. To change credentials run 'bitmaker logout' first."
+            "You already logged in. To change credentials run 'estela logout' first."
         )
 
     try:
@@ -122,7 +122,7 @@ def bm_command(username, password, host):
     except Exception as ex:
         raise click.ClickException(str(ex))
 
-    template = Template(BITMAKER_AUTH)
+    template = Template(ESTELA_AUTH)
     values = {
         "bm_host": bm_client.host,
         "bm_token": bm_client.token,
@@ -132,5 +132,5 @@ def bm_command(username, password, host):
     with open(bm_auth_path, "w") as bm_auth_yaml:
         bm_auth_yaml.write(result)
         click.echo(
-            "Successful login. API Token stored in ~/{}.".format(BITMAKER_AUTH_NAME)
+            "Successful login. API Token stored in ~/{}.".format(ESTELA_AUTH_NAME)
         )

--- a/bm_cli/logout.py
+++ b/bm_cli/logout.py
@@ -2,7 +2,7 @@ import click
 import os
 
 from bm_cli.utils import get_home_path
-from bm_cli.login import BITMAKER_AUTH_NAME
+from bm_cli.login import ESTELA_AUTH_NAME
 
 
 SHORT_HELP = "Remove your credentials"
@@ -11,11 +11,11 @@ SHORT_HELP = "Remove your credentials"
 @click.command(short_help=SHORT_HELP)
 def bm_command():
     home_path = get_home_path()
-    bm_auth_path = os.path.join(home_path, BITMAKER_AUTH_NAME)
+    bm_auth_path = os.path.join(home_path, ESTELA_AUTH_NAME)
 
     if not os.path.exists(bm_auth_path):
         raise click.ClickException(
-            "You have not logged in. Run 'bitmaker login' first."
+            "You have not logged in. Run 'estela login' first."
         )
 
     os.remove(bm_auth_path)

--- a/bm_cli/templates.py
+++ b/bm_cli/templates.py
@@ -1,8 +1,8 @@
 # Auth templates
 
-BITMAKER_AUTH_NAME = ".bitmaker.yaml"
+ESTELA_AUTH_NAME = ".estela.yaml"
 
-BITMAKER_AUTH = """\
+ESTELA_AUTH = """\
 token: $bm_token
 host: $bm_host
 """
@@ -10,7 +10,7 @@ host: $bm_host
 
 # Init project templates
 
-BITMAKER_DIR = ".bitmaker"
+ESTELA_DIR = ".estela"
 
 DATA_DIR = "project_data"
 
@@ -20,13 +20,13 @@ DOCKER_DEFAULT_PYTHON_VERSION = "3.6"
 
 DOCKER_DEFAULT_REQUIREMENTS = "requirements.txt"
 
-DOCKERFILE_NAME = "Dockerfile-bitmaker"
+DOCKERFILE_NAME = "Dockerfile-estela"
 
 DOCKERFILE = """\
 FROM python:$python_version
 
 # must be in base image
-RUN pip install git+https://github.com/bitmakerla/bitmaker-entrypoint.git
+RUN pip install git+https://github.com/estelala/estela-entrypoint.git
 
 RUN mkdir -p {app_dir}
 WORKDIR {app_dir}
@@ -38,9 +38,9 @@ RUN mkdir /fifo-data
     app_dir=DOCKER_APP_DIR
 )
 
-BITMAKER_YAML_NAME = "bitmaker.yaml"
+ESTELA_YAML_NAME = "estela.yaml"
 
-BITMAKER_YAML = """\
+ESTELA_YAML = """\
 project:
   pid: $project_pid
   python: $python_version

--- a/bm_cli/utils.py
+++ b/bm_cli/utils.py
@@ -5,9 +5,9 @@ import click
 
 from datetime import datetime
 from bm_cli.templates import (
-    BITMAKER_AUTH_NAME,
-    BITMAKER_YAML_NAME,
-    BITMAKER_DIR,
+    ESTELA_AUTH_NAME,
+    ESTELA_YAML_NAME,
+    ESTELA_DIR,
     DATA_DIR,
     DOCKERFILE_NAME,
 )
@@ -23,12 +23,12 @@ def get_home_path():
 
 def get_bm_yaml_path():
     project_path = get_project_path()
-    return os.path.join(project_path, BITMAKER_YAML_NAME)
+    return os.path.join(project_path, ESTELA_YAML_NAME)
 
 
 def get_bm_dockerfile_path():
     project_path = get_project_path()
-    return os.path.join(project_path, BITMAKER_DIR, DOCKERFILE_NAME)
+    return os.path.join(project_path, ESTELA_DIR, DOCKERFILE_NAME)
 
 
 def get_host_from_env():
@@ -46,7 +46,7 @@ def get_password_from_env():
 def get_bm_settings():
     bm_yaml_path = get_bm_yaml_path()
 
-    assert os.path.exists(bm_yaml_path), "{} not found.".format(BITMAKER_YAML_NAME)
+    assert os.path.exists(bm_yaml_path), "{} not found.".format(ESTELA_YAML_NAME)
 
     with open(bm_yaml_path, "r") as bm_yaml:
         bm_config = yaml.full_load(bm_yaml)
@@ -56,7 +56,7 @@ def get_bm_settings():
 
 def get_bm_auth():
     home_path = get_home_path()
-    bm_auth_path = os.path.join(home_path, BITMAKER_AUTH_NAME)
+    bm_auth_path = os.path.join(home_path, ESTELA_AUTH_NAME)
 
     if not os.path.exists(bm_auth_path):
         return None

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="bitmaker",
+    name="estela",
     version="0.1",
-    description="Bitmaker Command Line Interface",
+    description="Estela Command Line Interface",
     packages=find_packages(),
     entry_points={
         "console_scripts": [
-            "bitmaker = bm_cli.__main__:cli",
+            "estela = bm_cli.__main__:cli",
         ],
     },
     install_requires=[


### PR DESCRIPTION
# Ticket
- https://tasks.bitmaker.dev/issues/1804
# Description
- Change command master `bitmaker` to `estela`
- Change all ocurrence of Bitmaker (Cloud) to Estela.