### PR TITLE
BITMAKER-1862 Command line estela CLI to support UPDATE DataRetention fields

### DIFF
--- a/estela_cli/create/cronjob.py
+++ b/estela_cli/create/cronjob.py
@@ -5,7 +5,7 @@ from estela_cli.utils import (
     get_estela_settings,
     validate_key_value_format,
     set_tag_format,
-    set_day_format,
+    validate_positive,
 )
 
 
@@ -44,7 +44,7 @@ SHORT_HELP = "Create a new cronjob"
     "--day",
     "-d",
     type=click.INT,
-    callback=set_day_format,
+    callback=validate_positive,
     help="Set spider cronjob data expiry days",
 )
 def estela_command(sid, pid, schedule, arg, env, tag, day):

--- a/estela_cli/create/job.py
+++ b/estela_cli/create/job.py
@@ -5,7 +5,7 @@ from estela_cli.utils import (
     get_estela_settings,
     validate_key_value_format,
     set_tag_format,
-    set_day_format,
+    validate_positive,
 )
 
 
@@ -43,7 +43,7 @@ SHORT_HELP = "Create a new job"
     "--day",
     "-d",
     type=click.INT,
-    callback=set_day_format,
+    callback=validate_positive,
     help="Set spider job data expiry days",
 )
 def estela_command(sid, pid, arg, env, tag, day):

--- a/estela_cli/estela_client.py
+++ b/estela_cli/estela_client.py
@@ -219,13 +219,12 @@ class EstelaClient(EstelaSimpleClient):
         return response.json()
 
     
-    def update_spider_job(self, pid, sid, jid, day):
+    def update_spider_job(self, pid, sid, jid, day, persistent):
         endpoint = "projects/{}/spiders/{}/jobs/{}".format(pid, sid, jid)
-        data = {
-            # "status": status,
-            # "schedule": schedule,
-        }
-        if day and day >= 1:
+        data = {}   
+        if persistent:
+            data["data_status"] = "PERSISTENT"
+        elif day and day >= 1:
             data["data_status"] = "PENDING"
             data["data_expiry_days"] = day
 
@@ -234,12 +233,14 @@ class EstelaClient(EstelaSimpleClient):
         return response.json()
 
     
-    def update_spider_cronjob(self, pid, sid, cjid, status, schedule, day):
+    def update_spider_cronjob(self, pid, sid, cjid, status, schedule, day, persistent):
         endpoint = "projects/{}/spiders/{}/cronjobs/{}".format(pid, sid, cjid)
         data = {
             "status": status,
             "schedule": schedule,
         }
+        if persistent:
+            data["data_status"] = "PERSISTENT"
         if day and day >= 1:
             data["data_status"] = "PENDING"
             data["data_expiry_days"] = day

--- a/estela_cli/estela_client.py
+++ b/estela_cli/estela_client.py
@@ -187,7 +187,7 @@ class EstelaClient(EstelaSimpleClient):
             "tags": tags,
             "data_status": "PENDING" if day else "PERSISTENT",
         }
-        if day and day >= 1:
+        if day:
             data["data_expiry_days"] = f"{date.today() + timedelta(days=day)}"
 
         response = self.post(endpoint, data=data)
@@ -211,17 +211,16 @@ class EstelaClient(EstelaSimpleClient):
             "ctags": tags,
             "data_status": "PENDING" if day else "PERSISTENT",
         }
-        if day and day >= 1:
+        if day:
             data["data_expiry_days"] = f"0/{day}"
 
         response = self.post(endpoint, data=data)
         self.check_status(response, 201)
         return response.json()
 
-    
     def update_spider_job(self, pid, sid, jid, day, persistent):
         endpoint = "projects/{}/spiders/{}/jobs/{}".format(pid, sid, jid)
-        data = {}   
+        data = {}
         if persistent:
             data["data_status"] = "PERSISTENT"
         elif day and day >= 1:
@@ -232,7 +231,6 @@ class EstelaClient(EstelaSimpleClient):
         self.check_status(response, 200)
         return response.json()
 
-    
     def update_spider_cronjob(self, pid, sid, cjid, status, schedule, day, persistent):
         endpoint = "projects/{}/spiders/{}/cronjobs/{}".format(pid, sid, cjid)
         data = {

--- a/estela_cli/estela_client.py
+++ b/estela_cli/estela_client.py
@@ -218,12 +218,32 @@ class EstelaClient(EstelaSimpleClient):
         self.check_status(response, 201)
         return response.json()
 
-    def update_spider_cronjob(self, pid, sid, cjid, status, schedule):
+    
+    def update_spider_job(self, pid, sid, jid, day):
+        endpoint = "projects/{}/spiders/{}/jobs/{}".format(pid, sid, jid)
+        data = {
+            # "status": status,
+            # "schedule": schedule,
+        }
+        if day and day >= 1:
+            data["data_status"] = "PENDING"
+            data["data_expiry_days"] = day
+
+        response = self.put(endpoint, data=data)
+        self.check_status(response, 200)
+        return response.json()
+
+    
+    def update_spider_cronjob(self, pid, sid, cjid, status, schedule, day):
         endpoint = "projects/{}/spiders/{}/cronjobs/{}".format(pid, sid, cjid)
         data = {
             "status": status,
             "schedule": schedule,
         }
+        if day and day >= 1:
+            data["data_status"] = "PENDING"
+            data["data_expiry_days"] = day
+
         response = self.put(endpoint, data=data)
         self.check_status(response, 200)
         return response.json()

--- a/estela_cli/init.py
+++ b/estela_cli/init.py
@@ -52,7 +52,7 @@ def gen_estela_yaml(estela_client, pid=None):
     with open(estela_yaml_path, "w") as estela_yaml:
         estela_yaml.write(result)
         click.echo(
-            "{}/{} file created successfully.".format(ESTELA_DIR, ESTELA_YAML_NAME)
+            "{} file created successfully.".format(ESTELA_YAML_NAME)
         )
 
 

--- a/estela_cli/update/__init__.py
+++ b/estela_cli/update/__init__.py
@@ -9,7 +9,7 @@ def estela_command():
 
 commands = [
     "cronjob",
-    "job"
+    "job",
 ]
 
 for command in commands:

--- a/estela_cli/update/__init__.py
+++ b/estela_cli/update/__init__.py
@@ -9,6 +9,7 @@ def estela_command():
 
 commands = [
     "cronjob",
+    "job"
 ]
 
 for command in commands:

--- a/estela_cli/update/cronjob.py
+++ b/estela_cli/update/cronjob.py
@@ -23,12 +23,18 @@ VALID_STATUSES = ["ACTIVE", "DISABLED"]
     help="Set cronjob crontab schedule",
 )
 @click.option(
+    "--persistent",
+    "-p",
+    type=click.BOOL,
+    help="Set job data persistent (true/false)",
+)
+@click.option(
     "--day",
     "-d",
     type=click.INT,
     help="Set spider cronjob data expiry days",
 )
-def estela_command(cjid, sid, pid, status, schedule, day):
+def estela_command(cjid, sid, pid, status, schedule, day, persistent):
     """Update a cronjob
 
     \b
@@ -47,13 +53,13 @@ def estela_command(cjid, sid, pid, status, schedule, day):
                 "No active project in the current directory. Please specify the PID."
             )
 
-    if status is None and schedule is None and day is None:
+    if status is None and schedule is None and day is None and persistent is None:
         raise click.ClickException(
-            "Neither status nor schedule nor days was provided to update the cronjob. Please specify either or both."
+            "Neither status nor schedule nor days nor data_status was provided to update the cronjob. Please specify either or both."
         )
 
     try:
-        response = estela_client.update_spider_cronjob(pid, sid, cjid, status, schedule, day)
+        response = estela_client.update_spider_cronjob(pid, sid, cjid, status, schedule, day, persistent)
         click.echo(f"cronjob/spider-cjob-{cjid}-{pid} updated.")
     except Exception as ex:
         raise click.ClickException(

--- a/estela_cli/update/job.py
+++ b/estela_cli/update/job.py
@@ -1,10 +1,9 @@
 import click
 
 from estela_cli.login import login
-from estela_cli.utils import get_estela_settings
+from estela_cli.utils import get_estela_settings, validate_positive
 
 SHORT_HELP = "Update a job"
-VALID_STATUSES = ["ACTIVE", "DISABLED"]
 
 
 @click.command(short_help=SHORT_HELP)
@@ -13,15 +12,16 @@ VALID_STATUSES = ["ACTIVE", "DISABLED"]
 @click.argument("pid", required=False)
 @click.option(
     "--persistent",
-    "-p",
-    type=click.BOOL,
-    help="Set job data persistent",
+    is_flag=True,
+    default=None,
+    help="Set job data as persistent.",
 )
 @click.option(
     "--day",
     "-d",
     type=click.INT,
-    help="Set spider job data expiry days",
+    callback=validate_positive,
+    help="Set spider job data expiry days.",
 )
 def estela_command(jid, sid, pid, day, persistent):
     """Update a job
@@ -42,9 +42,9 @@ def estela_command(jid, sid, pid, day, persistent):
                 "No active project in the current directory. Please specify the PID."
             )
 
-    if day is None and persistent is None:
+    if all([option is None for option in [day, persistent]]):
         raise click.ClickException(
-            "Neither days nor data_status was not provided to update the job. Please specify the amount of days."
+            "No update option was provided to update the job. Please specify at least one."
         )
 
     try:

--- a/estela_cli/update/job.py
+++ b/estela_cli/update/job.py
@@ -11,30 +11,25 @@ VALID_STATUSES = ["ACTIVE", "DISABLED"]
 @click.argument("jid", required=True)
 @click.argument("sid", required=True)
 @click.argument("pid", required=False)
-# @click.option(
-#     "--status",
-#     type=click.Choice(VALID_STATUSES, case_sensitive=False),
-#     help="Set cronjob status",
-# )
-# @click.option(
-#     "--schedule",
-#     "-s",
-#     type=click.STRING,
-#     help="Set cronjob crontab schedule",
-# )
+@click.option(
+    "--persistent",
+    "-p",
+    type=click.BOOL,
+    help="Set job data persistent",
+)
 @click.option(
     "--day",
     "-d",
     type=click.INT,
-    help="Set spider cronjob data expiry days",
+    help="Set spider job data expiry days",
 )
-def estela_command(jid, sid, pid, day):
-    """Update a cronjob
+def estela_command(jid, sid, pid, day, persistent):
+    """Update a job
 
     \b
     SID is the spider's sid
     PID is the project's pid (active project by default)
-    CJID is the cronjob's cjid
+    JID is the job's jid
     """
 
     estela_client = login()
@@ -47,13 +42,13 @@ def estela_command(jid, sid, pid, day):
                 "No active project in the current directory. Please specify the PID."
             )
 
-    if day is None:
+    if day is None and persistent is None:
         raise click.ClickException(
-            "Days was not provided to update the job. Please specify the amount of days."
+            "Neither days nor data_status was not provided to update the job. Please specify the amount of days."
         )
 
     try:
-        response = estela_client.update_spider_job(pid, sid, jid, day)
+        response = estela_client.update_spider_job(pid, sid, jid, day, persistent)
         click.echo(f"job/spider-job-{jid}-{pid} updated.")
     except Exception as ex:
         raise click.ClickException(

--- a/estela_cli/update/job.py
+++ b/estela_cli/update/job.py
@@ -3,32 +3,32 @@ import click
 from estela_cli.login import login
 from estela_cli.utils import get_estela_settings
 
-SHORT_HELP = "Update a cronjob"
+SHORT_HELP = "Update a job"
 VALID_STATUSES = ["ACTIVE", "DISABLED"]
 
 
 @click.command(short_help=SHORT_HELP)
-@click.argument("cjid", required=True)
+@click.argument("jid", required=True)
 @click.argument("sid", required=True)
 @click.argument("pid", required=False)
-@click.option(
-    "--status",
-    type=click.Choice(VALID_STATUSES, case_sensitive=False),
-    help="Set cronjob status",
-)
-@click.option(
-    "--schedule",
-    "-s",
-    type=click.STRING,
-    help="Set cronjob crontab schedule",
-)
+# @click.option(
+#     "--status",
+#     type=click.Choice(VALID_STATUSES, case_sensitive=False),
+#     help="Set cronjob status",
+# )
+# @click.option(
+#     "--schedule",
+#     "-s",
+#     type=click.STRING,
+#     help="Set cronjob crontab schedule",
+# )
 @click.option(
     "--day",
     "-d",
     type=click.INT,
     help="Set spider cronjob data expiry days",
 )
-def estela_command(cjid, sid, pid, status, schedule, day):
+def estela_command(jid, sid, pid, day):
     """Update a cronjob
 
     \b
@@ -47,14 +47,14 @@ def estela_command(cjid, sid, pid, status, schedule, day):
                 "No active project in the current directory. Please specify the PID."
             )
 
-    if status is None and schedule is None and day is None:
+    if day is None:
         raise click.ClickException(
-            "Neither status nor schedule nor days was provided to update the cronjob. Please specify either or both."
+            "Days was not provided to update the job. Please specify the amount of days."
         )
 
     try:
-        response = estela_client.update_spider_cronjob(pid, sid, cjid, status, schedule, day)
-        click.echo(f"cronjob/spider-cjob-{cjid}-{pid} updated.")
+        response = estela_client.update_spider_job(pid, sid, jid, day)
+        click.echo(f"job/spider-job-{jid}-{pid} updated.")
     except Exception as ex:
         raise click.ClickException(
             "Some values are invalid or you do not have permission to perform this action."

--- a/estela_cli/utils.py
+++ b/estela_cli/utils.py
@@ -117,20 +117,17 @@ def validate_key_value_format(ctx, param, value):
         raise click.BadParameter("format must be 'NAME=VALUE'")
 
 
+def validate_positive(ctx, param, value):
+    if value is not None and value <= 0:
+        raise click.BadParameter("must be a positive integer.")
+    return value
+
+
 def set_tag_format(ctx, param, value):
     tags = []
     for tag_name in value:
         tags.append({"name": tag_name})
     return tags
-
-
-def set_day_format(ctx, param, value):
-    if value:
-        try:
-            return int(value)
-        except:
-            raise click.BadParameter("format must be a number")
-    return None
 
 
 def _in(path, ignore_files):


### PR DESCRIPTION
Description

There is not command that update DataStatus for jobs
Update Cronjob command doesn't allow data_expiry_days and data_status field, and it's required to create a job
estela CLI : https://github.com/bitmakerla/estela-cli/blob/master/estela_cli/

Completion Criteria:
- Add field data_expiry_days and data_status for update command line