### PR TITLE
BITMAKER-1840 estela: Configure repository descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+[![version](https://img.shields.io/badge/version-0.1-blue)](https://github.com/bitmakerla/estela)
+[![python-version](https://img.shields.io/badge/python-v3.10-orange)](https://www.python.org)
+[![build](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/bitmakerla/estela/actions)
+![CI](https://github.com/eslint/eslint/workflows/CI/badge.svg)
+
+
 Estela CLI is the command line client to interact with Estela API. Allows the user to perform the following actions:
 - Link a Scrapy project with a project in Estela.
 - Create projects, jobs, and cronjobs in Estela.


### PR DESCRIPTION
We need to define the badges, links, description, and GitHub topics of estela repositories:
Consider all the github editable fields that offer a better understanding of the repositories