### PR TITLE
BITMAKER-1901: Allow setting RAM limits to SpiderJobs

### DIFF
--- a/estela_cli/create/job.py
+++ b/estela_cli/create/job.py
@@ -3,11 +3,11 @@ import click
 from estela_cli.login import login
 from estela_cli.utils import (
     get_estela_settings,
-    validate_key_value_format,
     set_tag_format,
+    validate_key_value_format,
+    validate_limit,
     validate_positive,
 )
-
 
 SHORT_HELP = "Create a new job"
 
@@ -32,6 +32,13 @@ SHORT_HELP = "Create a new job"
     help="Set spider job environment variable NAME=VALUE (may be repeated)",
 )
 @click.option(
+    "--memory",
+    "-m",
+    type=click.STRING,
+    callback=validate_limit,
+    help="Set spider job memory limit (e.g. 256Mi, 1Gi).",
+)
+@click.option(
     "--tag",
     "-t",
     multiple=True,
@@ -46,7 +53,7 @@ SHORT_HELP = "Create a new job"
     callback=validate_positive,
     help="Set spider job data expiry days",
 )
-def estela_command(sid, pid, arg, env, tag, day):
+def estela_command(sid, pid, arg, env, memory, tag, day):
     """Create a new job
 
     \b
@@ -64,7 +71,7 @@ def estela_command(sid, pid, arg, env, tag, day):
                 "No active project in the current directory. Please specify the PID."
             )
     try:
-        response = estela_client.create_spider_job(pid, sid, arg, env, tag, day)
+        response = estela_client.create_spider_job(pid, sid, arg, env, memory, tag, day)
         click.echo("job/{} created.".format(response["name"]))
     except Exception as ex:
         raise click.ClickException("Cannot create the job for given SID and PID.")

--- a/estela_cli/estela_client.py
+++ b/estela_cli/estela_client.py
@@ -181,7 +181,9 @@ class EstelaClient(EstelaSimpleClient):
         self.check_status(response, 200)
         return response.json()
 
-    def create_spider_job(self, pid, sid, args=[], env_vars=[], tags=[], day=None):
+    def create_spider_job(
+        self, pid, sid, args=[], env_vars=[], memory=None, tags=[], day=None
+    ):
         endpoint = "projects/{}/spiders/{}/jobs".format(pid, sid)
         data = {
             "args": args,
@@ -191,6 +193,8 @@ class EstelaClient(EstelaSimpleClient):
         }
         if day:
             data["data_expiry_days"] = f"{date.today() + timedelta(days=day)}"
+        if memory:
+            data["limits"] = {"memory": memory}
 
         response = self.post(endpoint, data=data)
         self.check_status(response, 201)

--- a/estela_cli/list/job.py
+++ b/estela_cli/list/job.py
@@ -61,10 +61,11 @@ def estela_command(sid, pid, tag):
             format_tags(job["tags"]),
             format_key_value_pairs(job["args"]),
             format_key_value_pairs(job["env_vars"]),
+            job["limits"].get("memory", 0),
             format_time(job["created"]),
         ]
         for job in jobs
     ]
 
-    headers = ["JID", "STATUS", "TAGS", "ARGS", "ENV VARS", "CREATED"]
+    headers = ["JID", "STATUS", "TAGS", "ARGS", "ENV VARS", "MEMORY_LIMIT", "CREATED"]
     click.echo(tabulate(jobs, headers, numalign="left", tablefmt="plain"))

--- a/estela_cli/utils.py
+++ b/estela_cli/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import yaml
 import csv
 import json
@@ -145,6 +146,16 @@ def validate_key_value_format(ctx, param, value):
 def validate_positive(ctx, param, value):
     if value is not None and value <= 0:
         raise click.BadParameter("must be a positive integer.")
+    return value
+
+
+def validate_limit(ctx, param, value):
+    if value is not None:
+        match = re.match(r"^(\d+)(Mi|Gi)$", value)
+        if not match:
+            raise click.BadParameter(
+                "must be in a valid limit format (e.g. 256Mi, 1Gi)."
+            )
     return value
 
 


### PR DESCRIPTION
### Description:
- Added memory option for spider jobs to estela CLI.
- Usage: `estela create job 1 --memory 512Mi`. The specified limit is checked in the API and will fail if it is not within the allowed range.