### PR TITLE
BITMAKER-3024: Allow specifying data type for data retrieval

### DIFF
--- a/estela_cli/data/job.py
+++ b/estela_cli/data/job.py
@@ -1,20 +1,14 @@
 import time
 
-from email.policy import default
 import click
-from click import ClickException
 
 from estela_cli.login import login
-from estela_cli.utils import (
-    get_estela_settings,
-    get_project_path,
-    save_data,
-    save_chunk_data,
-)
-from estela_cli.templates import OK_EMOJI, BAD_EMOJI, CLOCK_EMOJI
+from estela_cli.templates import BAD_EMOJI, CLOCK_EMOJI, OK_EMOJI
+from estela_cli.utils import get_estela_settings, save_chunk_data, save_data
 
 SHORT_HELP = "Retrieve data from a job"
-ALLOWED_FORMATS = ["json", "csv"]
+ALLOWED_DATA_TYPES = ["items", "requests", "logs", "stats"]
+ALLOWED_DATA_FORMATS = ["json", "csv"]
 
 
 @click.command(short_help=SHORT_HELP)
@@ -22,23 +16,31 @@ ALLOWED_FORMATS = ["json", "csv"]
 @click.argument("sid", required=True)
 @click.argument("pid", required=False)
 @click.option(
+    "-t",
+    "--datatype",
+    type=click.Choice(ALLOWED_DATA_TYPES, case_sensitive=False),
+    default="items",
+)
+@click.option(
     "-f",
     "--format",
-    type=click.Choice(ALLOWED_FORMATS, case_sensitive=False),
+    type=click.Choice(ALLOWED_DATA_FORMATS, case_sensitive=False),
     default="json",
 )
 def estela_command(
     jid,
     sid,
     pid,
+    datatype,
     format,
 ):
-    """Retrieve all data from a given job
+    """Retrieve data from a given job
 
     \b
     SID is the spider's sid
     PID is the project's pid (active project by default)
     JID is the job's id
+    DATATYPE is the type of data to retrieve
     FORMAT is the format to retrieve data
     """
 
@@ -52,10 +54,10 @@ def estela_command(
                 "No active project in the current directory. Please specify the PID."
             )
 
-    tmp_filename = ".{}-{}-{}-tmp".format(jid, pid, time.time())
-    filename = "{}-{}.{}".format(jid, pid, format)
+    tmp_filename = ".{}-{}-{}-{}-tmp".format(jid, pid, datatype, time.time())
+    filename = "{}-{}-{}.{}".format(jid, pid, datatype, format)
     try:
-        response = estela_client.get_spider_job_data(pid, sid, jid)
+        response = estela_client.get_spider_job_data(pid, sid, jid, datatype)
         with click.progressbar(
             length=int(response["count"]),
             label="{} Downloading job data".format(CLOCK_EMOJI),
@@ -65,7 +67,7 @@ def estela_command(
         ) as progress_bar:
             next_chunk = None
             while True:
-                response = estela_client.get_spider_job_data(pid, sid, jid, next_chunk)
+                response = estela_client.get_spider_job_data(pid, sid, jid, datatype, next_chunk)
                 chunk = response.get("results")
                 save_chunk_data(tmp_filename, chunk)
                 progress_bar.update(len(chunk))
@@ -79,7 +81,7 @@ def estela_command(
         )
 
     try:
-        save_data(filename, tmp_filename)
+        save_data(filename, tmp_filename, format)
         click.echo("{} Data saved succesfully.".format(OK_EMOJI))
     except:
         raise click.ClickException("{} Could not save the job data".format(BAD_EMOJI))

--- a/estela_cli/estela_client.py
+++ b/estela_cli/estela_client.py
@@ -171,9 +171,9 @@ class EstelaClient(EstelaSimpleClient):
         self.check_status(response, 200)
         return response.json()
 
-    def get_spider_job_data(self, pid, sid, jid, last_chunk=None):
-        endpoint = "projects/{}/spiders/{}/jobs/{}/data?mode=paged".format(
-            pid, sid, jid
+    def get_spider_job_data(self, pid, sid, jid, datatype, last_chunk=None):
+        endpoint = "projects/{}/spiders/{}/jobs/{}/data?type={}".format(
+            pid, sid, jid, datatype
         )
         if last_chunk:
             endpoint += "&current_chunk={}".format(last_chunk)

--- a/estela_cli/utils.py
+++ b/estela_cli/utils.py
@@ -109,7 +109,7 @@ def save_chunk_data(filename, data):
             F.write(",")
 
 
-def save_data(filename, tmp_filename):
+def save_data(filename, tmp_filename, format):
     project_path = get_project_path()
     filename = os.path.join(project_path, DATA_DIR, filename)
     tmp_filename = os.path.join(project_path, DATA_DIR, tmp_filename)
@@ -118,9 +118,9 @@ def save_data(filename, tmp_filename):
         F.truncate()
         F.write(b"]\n")
 
-    if "json" in filename:
+    if format == "json":
         os.rename(tmp_filename, filename)
-    elif "csv" in filename:
+    elif format == "csv":
         with open(tmp_filename, "r", encoding="utf-8") as F:
             data = json.load(F)
         with open(filename, "w", encoding="utf-8") as F:


### PR DESCRIPTION
### Ticket:
- https://tasks.bitmaker.dev/issues/3024

### Description:
- Allow specifying what data type we want to retrieve using the `-t` or `--datatype` option.
- Use the `format` variable to check what format data should be saved.
- Sort imports. Removed unused imports.
- Removed the `mode=paged` parameter when querying the API since it has no effects.