### PR TITLE
BITMAKER-3375: Fix estela-cli not generating correctly Dockefiles with Phython versions 3.x0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.2.3
 commit = True
 tag = True
 tag_name = {new_version}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center"> estela CLI </h1>
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![version](https://img.shields.io/badge/version-0.2.2-blue)](https://github.com/bitmakerla/estela-cli)
+[![version](https://img.shields.io/badge/version-0.2.3-blue)](https://github.com/bitmakerla/estela-cli)
 [![python-version](https://img.shields.io/badge/python-v3.10-orange)](https://www.python.org)
 
 

--- a/estela_cli/__init__.py
+++ b/estela_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/estela_cli/deploy.py
+++ b/estela_cli/deploy.py
@@ -22,9 +22,8 @@ from estela_cli.templates import (
 SHORT_HELP = "Deploy Scrapy project to estela API"
 
 
-def zip_project(pid, project_path):
+def zip_project(pid, project_path, estela_settings):
     relroot = os.path.abspath(os.path.join(project_path, os.pardir))
-    estela_settings = get_estela_settings()
     archives_to_ignore = estela_settings["deploy"]["ignore"]
     with ZipFile("{}.zip".format(pid), "w", ZIP_DEFLATED) as zip:
         for root, dirs, files in os.walk(project_path):
@@ -88,7 +87,7 @@ def estela_command():
         p_settings["entrypoint"],
     )
 
-    zip_project(pid, project_path)
+    zip_project(pid, project_path, estela_settings)
 
     response = {}
     try:

--- a/estela_cli/templates.py
+++ b/estela_cli/templates.py
@@ -43,12 +43,12 @@ ESTELA_YAML_NAME = "estela.yaml"
 
 ESTELA_YAML = """\
 project:
-  pid: $project_pid
-  python: $python_version
-  requirements: $requirements_path
-  entrypoint: $entrypoint
+  pid: "$project_pid"
+  python: "$python_version"
+  requirements: "$requirements_path"
+  entrypoint: "$entrypoint"
 deploy:
-  ignore: [$project_data_path]
+  ignore: ["$project_data_path"]
 """
 
 # General templates

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="estela",
-    version="0.2.2",
+    version="0.2.3",
     description="Estela Command Line Interface",
     packages=find_packages(),
     entry_points={


### PR DESCRIPTION
### Ticket:
- https://tasks.bitmaker.dev/issues/3375

### Description:
- Python versions like `3.10` were treated as numbers, so the trailing zeros were trimmed, and the Dockerfile was generated with version `3.1`.